### PR TITLE
Update run_djipupper.py to send joint-space position commands

### DIFF
--- a/run_djipupper.py
+++ b/run_djipupper.py
@@ -91,8 +91,8 @@ def main(FLAGS):
                         state.activation = 0
                         continue
                     controller.run(state, command)
-                    hardware_interface.set_cartesian_positions(
-                        state.final_foot_locations
+                    hardware_interface.set_actuator_postions(
+                        state.joint_angles
                     )
                     last_loop = now
     except KeyboardInterrupt:


### PR DESCRIPTION
Update run_djipupper.py to send joint-space position commands rather than cartesian-space position commands. Experimental, ie haven't tested it on my own robot.